### PR TITLE
Bump django from 4.2.26 to 4.2.27 (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 (December 18, 2025)
+
+- Security patch from dependabot.
+
 ## 2.2.1 (November 7, 2025)
 
 - Security patch from dependabot.
@@ -13,7 +17,6 @@
 - Add parameter to filter only most prioritized media for each taxon in media query.
 - Import added columns in `facts_external_links_gbif.txt`.
 - Security mitigations from dependabot.
-
 
 ## 2.1.1 (October 20, 2024)
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 2.2.1
+  version: 2.2.2
   title: Nordic Microalgae
   description: API for Nordic Microalgae.
 servers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "nordicmicroalgae-backend"
-version = "2.2.1"
+version = "2.2.2"
 description = "Nordic Microalgae"
 authors = [
 ]
 dependencies = [
-    "Django==4.2.26",
+    "Django==4.2.27",
     "Pillow==10.4.0",
     "pyyaml==6.0.2",
     "psycopg==3.2.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ asgiref==3.9.2 \
     --hash=sha256:0b61526596219d70396548fc003635056856dba5d0d086f86476f10b33c75960 \
     --hash=sha256:a0249afacb66688ef258ffe503528360443e2b9a8d8c4581b6ebefa58c841ef1
     # via django
-django==4.2.26 \
-    --hash=sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a \
-    --hash=sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280
+django==4.2.27 \
+    --hash=sha256:b865fbe0f4a3d1ee36594c5efa42b20db3c8bbb10dff0736face1c6e4bda5b92 \
+    --hash=sha256:f393a394053713e7d213984555c5b7d3caeee78b2ccb729888a0774dff6c11a8
     # via nordicmicroalgae-backend
 pillow==10.4.0 \
     --hash=sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885 \

--- a/uv.lock
+++ b/uv.lock
@@ -43,16 +43,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.26"
+version = "4.2.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/f2/5cab08b4174b46cd9d5b4d4439d211f5dd15bec256fb43e8287adbb79580/django-4.2.26.tar.gz", hash = "sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a", size = 10433052, upload-time = "2025-11-05T14:08:23.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ff/6aa5a94b85837af893ca82227301ac6ddf4798afda86151fb2066d26ca0a/django-4.2.27.tar.gz", hash = "sha256:b865fbe0f4a3d1ee36594c5efa42b20db3c8bbb10dff0736face1c6e4bda5b92", size = 10432781, upload-time = "2025-12-02T14:01:49.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/6f/873365d280002de462852c20bcf050564e2354770041bd950bfb4a16d91e/django-4.2.26-py3-none-any.whl", hash = "sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280", size = 7994264, upload-time = "2025-11-05T14:08:20.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f5/1a2319cc090870bfe8c62ef5ad881a6b73b5f4ce7330c5cf2cb4f9536b12/django-4.2.27-py3-none-any.whl", hash = "sha256:f393a394053713e7d213984555c5b7d3caeee78b2ccb729888a0774dff6c11a8", size = 7995090, upload-time = "2025-12-02T14:01:44.234Z" },
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ wheels = [
 
 [[package]]
 name = "nordicmicroalgae-backend"
-version = "2.2.1"
+version = "2.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
@@ -124,7 +124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = "==4.2.26" },
+    { name = "django", specifier = "==4.2.27" },
     { name = "pillow", specifier = "==10.4.0" },
     { name = "psycopg", specifier = "==3.2.3" },
     { name = "pyyaml", specifier = "==6.0.2" },


### PR DESCRIPTION
* Bump django from 4.2.26 to 4.2.27

Bumps [django](https://github.com/django/django) from 4.2.26 to 4.2.27.
- [Commits](https://github.com/django/django/compare/4.2.26...4.2.27)

---
updated-dependencies:
- dependency-name: django dependency-version: 4.2.27 dependency-type: direct:production ...



* update uv.lock

* bump version

* update uv.lock

---------